### PR TITLE
Update the url for official Chainer tutorial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ ref [Chainer.wiki](https://github.com/chainer/chainer/wiki) - Chainer Wiki
 
 <a name="github-tutorials" />
 
-## Tutorials
+## Guides
 
-* [Chainer Tutorial Offical document](http://docs.chainer.org/en/latest/tutorial/index.html) - Chainer Tutorial Offical document
+* [Chainer Offical Guides](https://docs.chainer.org/en/stable/guides/index.html) - Chainer guides in the offical document
 
 ## Hands-on
 


### PR DESCRIPTION
This PR aims to fix the corrupted URL of the Chainer tutorial.

I found that the current [URL](https://docs.chainer.org/en/latest/tutorial/index.html) for Chainer official tutorial is not correct. In fact, there are only `Guides` available on Chainer official document. So I modified the name to `Guides`, and also uses the ["stable" version's URL](https://docs.chainer.org/en/stable/guides/index.html).